### PR TITLE
Fix tests, fix blessings!

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -263,15 +263,15 @@ class Terminal(object):
         def get_winsize(tty_fd):
             """Returns the value of the ``winsize`` struct for the terminal
                specified by argument ``tty_fd`` as four integers:
-                 (rows, cols, xheight, yheight).
-               The first pair are character cells, the latter pixels.
+                 (lines, cols, y_height, x_height).
+               The first pair are character cells, the latter pixel size.
             """
             val = ioctl(tty_fd, TIOCGWINSZ, '\x00' * 8)
             return struct.unpack('hhhh', val)
 
         for descriptor in self._init_descriptor, sys.__stdout__:
             try:
-                cols, lines, _xp, _yp = get_winsize(descriptor)
+                lines, cols, _yp, _xp = get_winsize(descriptor)
                 return lines, cols
             except IOError:
                 # when output stream, and init_descriptor stdout, is piped

--- a/blessings/tests.py
+++ b/blessings/tests.py
@@ -161,13 +161,13 @@ def test_height_and_width_ioctl():
             TIOCSWINSZ = -2146929561
 
         # set the pty's virtual window size
-        val = struct.pack('HHHH', cols, lines, 0, 0)
+        val = struct.pack('HHHH', lines, cols, 0, 0)
         ioctl(sys.__stdout__.fileno(), TIOCSWINSZ, val)
 
-        # test virtual size and exit 0
+        # test new virtual window size
         eq_(Terminal()._height_and_width(), (lines, cols))
-        # note: stderr is never buffered, unlike stdout which is line-buffered,
-        # one of those nice-to-knows.
+        eq_(Terminal().height, lines)
+        eq_(Terminal().width, cols)
     child()
 
 def test_stream_attr():


### PR DESCRIPTION
With the setupterm() singleton issue #33 worked around with pty.fork(), we can now be much more assured about our test cases. Several existing test cases that previously succeeded began to fail! Some failed simply because they were "corrected" to match the behavior discovered at that time, but was wrong. Others failed because of errors within blessings/**init**.py that were previously undiscovered.

Notably:
- warning emitted for subsequent Terminal() instances of different `kind` values, explaining the expected behavior.
- height and width always returns a digit, even without ttys (prevents TypeError)
- number_of_colors returns 0 when does_styling is False (prevents "setupterm() must first be called")
- NullCallableStrings return NullCallableStrings, resolving t.color(9)('shmoo') (prevents exception: unicode cannot be called)
- remove the pokemon curses.error silent handler (prevents exceptions from being missed!)
- as_subprocess decorator function executes the function in a child process of pty.fork(), the parent re-displays any exceptions thrown, asserts its exit value, etc. This ensures setupterm() is called once, freshly, for each child process.
- test_height_and_width_ioctl: set a window to a specific size, then assert the return values of t.height and t.width are correct, and not just integers.

Minors:
- assert no side-effects written to output stream where StringIO() is used. child processes that write to stdout will always be a "failed test case" as well, performing the same.
- many minor fixes to test cases, perhaps some behaviors you were not aware of, such as misspellings are not errors when the terminal is not a tty.
- check 0 and 8 number_of_colors than just 256, now that this is possible.
- new test cases for TypeError's, passing wrong parameters to capabilities (some of these may have been previously missed due to the pokemon exception handler)

that about sums it up, hope this suites better than the previous.
