### PR TITLE
Support (and tests) for tuples with nested styles

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -468,15 +468,38 @@ class FormattingString(unicode):
         new._normal = normal
         return new
 
-    def __call__(self, text):
-        """Return a new string that is ``text`` formatted with my contents.
+    def __call__(self, *args):
+        """Return a new string that is formatted with my contents. 
+        
+        The content of the new string is a concatentaion of the args passed in,
+        which should be simple strings or FormattingStrings (allows nested
+        calls for "inner" style).
+
+        For example, this creates a red phrase with some bold words in the middle:
+          t.red('This is ', t.bold('extremely important'), ' information!')
 
         At the beginning of the string, I prepend the formatting that is my
         contents. At the end, I append the "normal" sequence to set everything
         back to defaults. The return value is always a Unicode.
 
         """
-        return self + text + self._normal
+
+        # complain if there are funky (non-string) args
+        for a in args:
+            if not isinstance(a, basestring):
+                raise TypeError(
+                    'Calls to a FormattingString should pass a series of strings '
+                    '(str or unicode). Something here does not belong: %r' % (args,))
+
+        if self._normal:
+            # "refresh" my style in the inner text by inserting it after each 'normal' (reset) code
+            refresh = self._normal + self
+            args = [refresh.join(a.split(self._normal)) for a in args]
+        else:    
+            # if self._normal is empty, there's no tty so nothing to do here
+            pass
+
+        return self + "".join(args) + self._normal
 
 
 class NullCallableString(unicode):
@@ -508,7 +531,7 @@ class NullCallableString(unicode):
         the first arg. I am acting as a ``FormattingString``.
 
         """
-        if len(args) != 1 or isinstance(args[0], int):
+        if len(args) == 0 or isinstance(args[0], int):
             # I am acting as a ParametrizingString.
 
             # tparm can take not only ints but also (at least) strings as its
@@ -519,7 +542,7 @@ class NullCallableString(unicode):
             # NullParametrizableString or NullFormattingString, to return, and
             # retire this one.
             return u''
-        return args[0]  # Should we force even strs in Python 2.x to be
+        return "".join(args) # Should we force even strs in Python 2.x to be
                         # unicodes? No. How would I know what encoding to use
                         # to convert it?
 

--- a/blessings/tests.py
+++ b/blessings/tests.py
@@ -211,6 +211,14 @@ def test_formatting_functions():
     eq_(t.on_bright_red_bold_bright_green_underline('meh'),
         t.on_bright_red + t.bold + t.bright_green + t.underline + u'meh' +
                           t.normal)
+    # Test deeply nested styles
+    eq_(t.green('foo', t.bold('bar', t.underline('baz'), 'herp'), 'derp'),
+        t.green + 'foo' + t.bold + 'bar' + t.underline + 'baz' + t.normal + t.green + t.bold + 
+        'herp' + t.normal + t.green + 'derp' + t.normal)
+    # Test off-and-on nested styles
+    eq_(t.green('off ', t.underline('ON'), ' off ', t.underline('ON'), ' off'),
+        t.green + 'off ' + t.underline + 'ON' + t.normal + t.green  + ' off ' +
+        t.underline + 'ON' + t.normal + t.green + ' off' + t.normal)
 
 
 def test_formatting_functions_without_tty():
@@ -222,6 +230,12 @@ def test_formatting_functions_without_tty():
     eq_(t.bold_green(u'boö'), u'boö')
     eq_(t.bold_underline_green_on_red('loo'), u'loo')
     eq_(t.on_bright_red_bold_bright_green_underline('meh'), u'meh')
+    # Test deeply nested styles
+    eq_(t.green('foo', t.bold('bar', t.underline('baz'), 'herp'), 'derp'),
+        'foobarbazherpderp')
+    # Test off-and-on nested styles
+    eq_(t.green('off ', t.underline('ON'), ' off ', t.underline('ON'), ' off'),
+        'off ON off ON off')
 
 
 def test_nice_formatting_errors():


### PR DESCRIPTION
In some cases, it would be nice if we could "nest" styles by passing tuples, like so:

``` python
# creates a red phrase with some bold words in the middle:
t.red('This is ', t.bold('extremely important'), ' information!')

# deeper nesting of styles (green, then bold, then underline, and back out)
t.green('foo', t.bold('bar', t.underline('baz'), 'herp'), 'derp')
```

I've added tests with and without TTY, and so far it seems robust. Thoughts?
