### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.5
   - 2.6
   - 2.7
   - 3.2


### PR DESCRIPTION
The build is failing because of this: https://github.com/travis-ci/travis-ci/issues/1668 which states that python2.5 has been removed from travis.
