### PR TITLE
Redesign the input API a bit

### DIFF
--- a/bin/on_resize.py
+++ b/bin/on_resize.py
@@ -4,8 +4,8 @@ This is an example application for the 'blessed' Terminal library for python.
 
 Window size changes are caught by the 'on_resize' function using a traditional
 signal handler.  Meanwhile, blocking keyboard input is displayed to stdout.
-If a resize event is discovered, an empty string is returned by term.inkey()
-when _intr_continue is False, as it is here.
+If a resize event is discovered, an empty string is returned by
+term.keystroke() when interruptable is False, as it is here.
 """
 import signal
 from blessed import Terminal
@@ -31,5 +31,5 @@ with term.raw():
     print("press 'X' to stop.\r")
     inp = None
     while inp != 'X':
-        inp = term.inkey(_intr_continue=False)
+        inp = term.inkey(interruptable=False)
         print(repr(inp) + u'\r')

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -250,7 +250,6 @@ DEFAULT_SEQUENCE_MIXIN = (
     (u"\x1bOx", curses.KEY_KP_8),          # 8
     (u"\x1bOy", curses.KEY_KP_9),          # 9
 
-    #
     # keypad, numlock off
     (u"\x1b[1~", curses.KEY_FIND),         # find
     (u"\x1b[2~", curses.KEY_IC),           # insert (0)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -199,7 +199,7 @@ class Terminal(object):
                 else:
                     warnings.warn(
                         'A terminal of kind "%s" has been requested; due to an'
-                        ' internal python curses bug,  terminal capabilities'
+                        ' internal python curses bug, terminal capabilities'
                         ' for a terminal of kind "%s" will continue to be'
                         ' returned for the remainder of this process.' % (
                             self._kind, _CUR_TERM,))
@@ -534,12 +534,12 @@ class Terminal(object):
 
         return lines
 
-    def getch(self):
-        """T.getch() -> unicode
+    def _next_char(self):
+        """T._next_char() -> unicode
 
         Read and decode next byte from keyboard stream.  May return u''
         if decoding is not yet complete, or completed unicode character.
-        Should always return bytes when self.kbhit() returns True.
+        Should always return bytes when self._char_is_ready() returns True.
 
         Implementors of input streams other than os.read() on the stdin fd
         should derive and override this method.
@@ -548,8 +548,8 @@ class Terminal(object):
         byte = os.read(self.keyboard_fd, 1)
         return self._keyboard_decoder.decode(byte, final=False)
 
-    def kbhit(self, timeout=None, _intr_continue=True):
-        """T.kbhit([timeout=None]) -> bool
+    def _char_is_ready(self, timeout=None, _intr_continue=True):
+        """T._char_is_ready([timeout=None]) -> bool
 
         Returns True if a keypress has been detected on keyboard.
 
@@ -590,15 +590,20 @@ class Terminal(object):
         return False if self.keyboard_fd is None else check_r == ready_r
 
     @contextlib.contextmanager
-    def cbreak(self):
-        """Return a context manager that enters 'cbreak' mode: disabling line
-        buffering of keyboard input, making characters typed by the user
-        immediately available to the program.  Also referred to as 'rare'
-        mode, this is the opposite of 'cooked' mode, the default for most
-        shells.
+    def keystroke_input(self, raw=False):
+        """Return a context manager that sets up the terminal to do
+        key-at-a-time input.
 
-        In 'cbreak' mode, echo of input is also disabled: the application must
-        explicitly print any input received, if they so wish.
+        On entering the context manager, "cbreak" mode is activated, disabling
+        line buffering of keyboard input and turning off automatic echoing of
+        input. (You must explicitly print any input if you'd like it shown.)
+        Also referred to as 'rare' mode, this is the opposite of 'cooked' mode,
+        the default for most shells.
+
+        If ``raw`` is True, enter "raw" mode instead. Raw mode differs in that
+        the interrupt, quit, suspend, and flow control characters are all
+        passed through as their raw character values instead of generating a
+        signal.
 
         More information can be found in the manual page for curses.h,
         http://www.openbsd.org/cgi-bin/man.cgi?query=cbreak
@@ -610,35 +615,14 @@ class Terminal(object):
         http://www.unixwiz.net/techtips/termios-vmin-vtime.html
         """
         if HAS_TTY and self.keyboard_fd is not None:
-            # save current terminal mode,
+            # Save current terminal mode:
             save_mode = termios.tcgetattr(self.keyboard_fd)
-            tty.setcbreak(self.keyboard_fd, termios.TCSANOW)
+            mode_setter = tty.setraw if raw else tty.setcbreak
+            mode_setter(self.keyboard_fd, termios.TCSANOW)
             try:
                 yield
             finally:
-                # restore prior mode,
-                termios.tcsetattr(self.keyboard_fd,
-                                  termios.TCSAFLUSH,
-                                  save_mode)
-        else:
-            yield
-
-    @contextlib.contextmanager
-    def raw(self):
-        """Return a context manager that enters *raw* mode. Raw mode is
-        similar to *cbreak* mode, in that characters typed are immediately
-        available to ``inkey()`` with one exception: the interrupt, quit,
-        suspend, and flow control characters are all passed through as their
-        raw character values instead of generating a signal.
-        """
-        if HAS_TTY and self.keyboard_fd is not None:
-            # save current terminal mode,
-            save_mode = termios.tcgetattr(self.keyboard_fd)
-            tty.setraw(self.keyboard_fd, termios.TCSANOW)
-            try:
-                yield
-            finally:
-                # restore prior mode,
+                # Restore prior mode:
                 termios.tcsetattr(self.keyboard_fd,
                                   termios.TCSAFLUSH,
                                   save_mode)
@@ -667,8 +651,8 @@ class Terminal(object):
         finally:
             self.stream.write(self.rmkx)
 
-    def inkey(self, timeout=None, esc_delay=0.35, _intr_continue=True):
-        """T.inkey(timeout=None, [esc_delay, [_intr_continue]]) -> Keypress()
+    def keystroke(self, timeout=None, esc_delay=0.35, _intr_continue=True):
+        """T.keystroke(timeout=None, [esc_delay, [_intr_continue]]) -> Keystroke
 
         Receive next keystroke from keyboard (stdin), blocking until a
         keypress is received or ``timeout`` elapsed, if specified.
@@ -683,7 +667,7 @@ class Terminal(object):
         attributes of this terminal beginning with *KEY*, such as
         ``KEY_ESCAPE``.
 
-        To distinguish between ``KEY_ESCAPE``, and sequences beginning with
+        To distinguish between ``KEY_ESCAPE`` and sequences beginning with
         escape, the ``esc_delay`` specifies the amount of time after receiving
         the escape character (chr(27)) to seek for the completion
         of other application keys before returning ``KEY_ESCAPE``.
@@ -691,8 +675,8 @@ class Terminal(object):
         Normally, when this function is interrupted by a signal, such as the
         installment of SIGWINCH, this function will ignore this interruption
         and continue to poll for input up to the ``timeout`` specified. If
-        you'd rather this function return ``u''`` early, specify a value
-        of ``False`` for ``_intr_continue``.
+        you'd rather this function return ``u''`` early, specify ``False`` for
+        ``_intr_continue``.
         """
         # TODO(jquast): "meta sends escape", where alt+1 would send '\x1b1',
         #               what do we do with that? Surely, something useful.
@@ -700,14 +684,21 @@ class Terminal(object):
         # TODO(jquast): Ctrl characters, KEY_CTRL_[A-Z], and the rest;
         #               KEY_CTRL_\, KEY_CTRL_{, etc. are not legitimate
         #               attributes. comparator to term.KEY_ctrl('z') ?
-        def _timeleft(stime, timeout):
-            """_timeleft(stime, timeout) -> float
+        
+        if timeout is None and self.keyboard_fd is None:
+            raise NoKeyboard(
+                    'Waiting for a keystroke on a terminal with no keyboard '
+                    'attached and no timeout would take a long time. Add a '
+                    'timeout and revise your program logic.')
+        
+        def time_left(stime, timeout):
+            """time_left(stime, timeout) -> float
 
             Returns time-relative time remaining before ``timeout``
             after time elapsed since ``stime``.
             """
             if timeout is not None:
-                if timeout is 0:
+                if timeout == 0:
                     return 0
                 return max(0, timeout - (time.time() - stime))
 
@@ -723,8 +714,8 @@ class Terminal(object):
             ucs += self._keyboard_buf.pop()
 
         # receive all immediately available bytes
-        while self.kbhit(0):
-            ucs += self.getch()
+        while self._char_is_ready(0):
+            ucs += self._next_char()
 
         # decode keystroke, if any
         ks = resolve(text=ucs)
@@ -732,8 +723,8 @@ class Terminal(object):
         # so long as the most immediately received or buffered keystroke is
         # incomplete, (which may be a multibyte encoding), block until until
         # one is received.
-        while not ks and self.kbhit(_timeleft(stime, timeout), _intr_continue):
-            ucs += self.getch()
+        while not ks and self._char_is_ready(time_left(stime, timeout), _intr_continue):
+            ucs += self._next_char()
             ks = resolve(text=ucs)
 
         # handle escape key (KEY_ESCAPE) vs. escape sequence (which begins
@@ -741,16 +732,22 @@ class Terminal(object):
         # received. This is not optimal, but causes least delay when
         # (currently unhandled, and rare) "meta sends escape" is used,
         # or when an unsupported sequence is sent.
-        if ks.code is self.KEY_ESCAPE:
+        if ks.code == self.KEY_ESCAPE:
             esctime = time.time()
-            while (ks.code is self.KEY_ESCAPE and
-                   self.kbhit(_timeleft(esctime, esc_delay))):
-                ucs += self.getch()
+            while (ks.code == self.KEY_ESCAPE and
+                   self._char_is_ready(time_left(esctime, esc_delay))):
+                ucs += self._next_char()
                 ks = resolve(text=ucs)
 
         # buffer any remaining text received
         self._keyboard_buf.extendleft(ucs[len(ks):])
         return ks
+
+
+class NoKeyboard(Exception):
+    """Exception raised when a Terminal that has no means of input connected is
+    asked to retrieve a keystroke without an infinite timeout."""
+
 
 # From libcurses/doc/ncurses-intro.html (ESR, Thomas Dickey, et. al):
 #

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -548,7 +548,7 @@ class Terminal(object):
         byte = os.read(self.keyboard_fd, 1)
         return self._keyboard_decoder.decode(byte, final=False)
 
-    def _char_is_ready(self, timeout=None, _intr_continue=True):
+    def _char_is_ready(self, timeout=None, interruptable=True):
         """T._char_is_ready([timeout=None]) -> bool
 
         Returns True if a keypress has been detected on keyboard.
@@ -574,7 +574,7 @@ class Terminal(object):
                 ready_r, ready_w, ready_x = select.select(
                     check_r, check_w, check_x, timeout)
             except InterruptedError:
-                if not _intr_continue:
+                if not interruptable:
                     return u''
                 if timeout is not None:
                     # subtract time already elapsed,
@@ -651,8 +651,8 @@ class Terminal(object):
         finally:
             self.stream.write(self.rmkx)
 
-    def keystroke(self, timeout=None, esc_delay=0.35, _intr_continue=True):
-        """T.keystroke(timeout=None, [esc_delay, [_intr_continue]]) -> Keystroke
+    def keystroke(self, timeout=None, esc_delay=0.35, interruptable=True):
+        """T.keystroke(timeout=None, [esc_delay, [interruptable]]) -> Keystroke
 
         Receive next keystroke from keyboard (stdin), blocking until a
         keypress is received or ``timeout`` elapsed, if specified.
@@ -676,7 +676,7 @@ class Terminal(object):
         installment of SIGWINCH, this function will ignore this interruption
         and continue to poll for input up to the ``timeout`` specified. If
         you'd rather this function return ``u''`` early, specify ``False`` for
-        ``_intr_continue``.
+        ``interruptable``.
         """
         # TODO(jquast): "meta sends escape", where alt+1 would send '\x1b1',
         #               what do we do with that? Surely, something useful.
@@ -723,7 +723,8 @@ class Terminal(object):
         # so long as the most immediately received or buffered keystroke is
         # incomplete, (which may be a multibyte encoding), block until until
         # one is received.
-        while not ks and self._char_is_ready(time_left(stime, timeout), _intr_continue):
+        while not ks and self._char_is_ready(time_left(stime, timeout),
+                                             interruptable):
             ucs += self._next_char()
             ks = resolve(text=ucs)
 

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -172,7 +172,8 @@ def test_char_is_ready_interrupted_interruptable():
 
 
 def test_char_is_ready_interrupted_nonetype_interruptable():
-    "_char_is_ready() may be interrupted when interruptable=False with timeout None."
+    """_char_is_ready() may be interrupted when interruptable=False with
+    timeout None."""
     pid, master_fd = pty.fork()
     if pid is 0:
         try:

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -127,8 +127,8 @@ def test_char_is_ready_interrupted_nonetype():
     assert math.floor(time.time() - stime) == 1.0
 
 
-def test_char_is_ready_interrupted_no_continue():
-    "_char_is_ready() may be interrupted when _intr_continue=False."
+def test_char_is_ready_interrupted_interruptable():
+    "_char_is_ready() may be interrupted when interruptable=False."
     pid, master_fd = pty.fork()
     if pid is 0:
         try:
@@ -149,7 +149,7 @@ def test_char_is_ready_interrupted_no_continue():
         read_until_semaphore(sys.__stdin__.fileno(), semaphore=SEMAPHORE)
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.keystroke_input(raw=True):
-            term.keystroke(timeout=1.05, _intr_continue=False)
+            term.keystroke(timeout=1.05, interruptable=False)
         os.write(sys.__stdout__.fileno(), b'complete')
         assert got_sigwinch is True
         if cov is not None:
@@ -171,8 +171,8 @@ def test_char_is_ready_interrupted_no_continue():
     assert math.floor(time.time() - stime) == 0.0
 
 
-def test_char_is_ready_interrupted_nonetype_no_continue():
-    "_char_is_ready() may be interrupted when _intr_continue=False with timeout None."
+def test_char_is_ready_interrupted_nonetype_interruptable():
+    "_char_is_ready() may be interrupted when interruptable=False with timeout None."
     pid, master_fd = pty.fork()
     if pid is 0:
         try:
@@ -193,7 +193,7 @@ def test_char_is_ready_interrupted_nonetype_no_continue():
         read_until_semaphore(sys.__stdin__.fileno(), semaphore=SEMAPHORE)
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.keystroke_input(raw=True):
-            term.keystroke(timeout=None, _intr_continue=False)
+            term.keystroke(timeout=None, interruptable=False)
         os.write(sys.__stdout__.fileno(), b'complete')
         assert got_sigwinch is True
         if cov is not None:


### PR DESCRIPTION
Redesign the input API a bit to guide the caller toward proper use and to divide state. (See commit message.)

test_inkey_0s_raw_ctrl_c fails but only when running `py.test blessed/tests/test_keyboard.py --tb=short`, not when running the whole suite:

    _________________________________________ test_inkey_0s_raw_ctrl_c __________________________________________
    blessed/tests/test_keyboard.py:424: in test_inkey_0s_raw_ctrl_c
        os.write(master_fd, u'\x03'.encode('latin1'))
    E   OSError: [Errno 5] Input/output error


I'm not sure offhand why. Any ideas?
 
And then test_key_mode_no_kb's raises() appears to not work when running the whole suite. When running just test_keyboard, it's fine.

    ____________________________________________ test_key_mode_no_kb ____________________________________________
    blessed/tests/test_keyboard.py:229: in test_key_mode_no_kb
        child()
    blessed/tests/accessories.py:122: in __call__
        assert exc_output == '', exc_output_msg
    E   AssertionError: Output in child process:
    E   ========================================
    E     File "/Users/grinch/Checkouts/blessings/blessed/tests/accessories.py", line 76, in __call__
    E       self.func(*args, **kwargs)
    E     File "/Users/grinch/Checkouts/blessings/blessed/tests/test_keyboard.py", line 227, in child
    E       with term.key_mode():
    E     File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 17, in __enter__
    E       return self.gen.next()
    E     File "/Users/grinch/Checkouts/blessings/blessed/terminal.py", line 577, in key_mode
    E       raise NoKeyboard
    E   -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    E   NoKeyboard
    E   ========================================

But that aside, this is ready for feedback.

What do you think? I'm particularly interested in your opinion on key_mode() raising an immediate NoKeyboard exception if there's no keyboard or tty attached. I don't see much call for setting cbreak or raw mode unless you can also take input (in which case we'd defer the error until key() was called), but you may know something I don't.