### PR TITLE
Input apis somedocs and testfix

### DIFF
--- a/bin/keymatrix.py
+++ b/bin/keymatrix.py
@@ -73,13 +73,13 @@ def main():
     gb = build_gameboard(term)
     inps = []
 
-    with term.raw(), term.keypad(), term.location():
-        inp = term.inkey(timeout=0)
+    with term.keypad(), term.location(), term.keymode(raw=True) as inkey:
+        inp = inkey(timeout=0)
         while inp != chr(3):
             if dirty:
                 refresh(term, gb, level, score, inps)
                 dirty = False
-            inp = term.inkey(timeout=5.0)
+            inp = inkey(timeout=5.0)
             dirty = True
             if (inp.is_sequence and
                     inp.name in gb and
@@ -112,7 +112,7 @@ def main():
                 hit_highbit=hit_highbit,
                 hit_unicode=hit_unicode)
         )
-        term.inkey()
+        inkey()
 
 if __name__ == '__main__':
     main()

--- a/bin/on_resize.py
+++ b/bin/on_resize.py
@@ -4,7 +4,7 @@ This is an example application for the 'blessed' Terminal library for python.
 
 Window size changes are caught by the 'on_resize' function using a traditional
 signal handler.  Meanwhile, blocking keyboard input is displayed to stdout.
-If a resize event is discovered, an empty string is returned by term.inkey()
+If a resize event is discovered, an empty string is returned by ``inkey()``
 when _intr_continue is False, as it is here.
 """
 import signal
@@ -27,9 +27,9 @@ signal.signal(signal.SIGWINCH, on_resize)
 # interference of such driver -- so we must write \r\n ourselves; as python
 # will append '\n' to our print statements, we simply end our statements with
 # \r.
-with term.raw():
+with term.key_mode(raw=True) as inkey:
     print("press 'X' to stop.\r")
     inp = None
     while inp != 'X':
-        inp = term.inkey(_intr_continue=False)
+        inp = inkey(_intr_continue=False)
         print(repr(inp) + u'\r')

--- a/bin/progress_bar.py
+++ b/bin/progress_bar.py
@@ -19,7 +19,7 @@ def main():
         'Terminal does not support hpa (Horizontal position absolute)')
 
     col, offset = 1, 1
-    with term.cbreak():
+    with term.key_mode() as inkey:
         inp = None
         print("press 'X' to stop.")
         sys.stderr.write(term.move(term.height, 0) + u'[')
@@ -33,7 +33,7 @@ def main():
             col += offset
             sys.stderr.write(term.move_x(col) + u'|\b')
             sys.stderr.flush()
-            inp = term.inkey(0.04)
+            inp = inkey(0.04)
     print()
 
 if __name__ == '__main__':

--- a/bin/worms.py
+++ b/bin/worms.py
@@ -148,7 +148,7 @@ def main():
     modifier = 0.93
     inp = None
 
-    with term.hidden_cursor(), term.raw():
+    with term.hidden_cursor(), term.key_mode(raw=True) as inkey:
         while inp not in (u'q', u'Q'):
 
             # delete the tail of the worm at worm_length
@@ -194,7 +194,7 @@ def main():
 
             # wait for keyboard input, which may indicate
             # a new direction (up/down/left/right)
-            inp = term.inkey(speed)
+            inp = inkey(speed)
 
             # discover new direction, given keyboard input and/or bearing.
             nxt_direction = next_bearing(term, inp.code, bearing)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -51,8 +51,7 @@ from .sequences import (
 from .keyboard import (
     get_keyboard_sequences,
     get_keyboard_codes,
-    BufferedKeyboard,
-    resolve_sequence,
+    BufferedKeyboard
 )
 
 
@@ -562,12 +561,13 @@ class Terminal(object):
             mode_setter = tty.setraw if raw else tty.setcbreak
             mode_setter(self.keyboard_fd, termios.TCSANOW)
             try:
-                yield BufferedKeyboard(self._keymap,
-                                       self._keycodes,
-                                       self.KEY_ESCAPE,
-                                       self.keyboard_fd,
-                                       self._keyboard_decoder,
-                                       HAS_TTY).key
+                yield BufferedKeyboard(
+                    keymap=self._keymap,
+                    keycodes=self._keycodes,
+                    escape=self.KEY_ESCAPE,
+                    keyboard_fd=self.keyboard_fd,
+                    keyboard_decoder=self._keyboard_decoder
+                ).key
             finally:
                 # Restore prior mode:
                 termios.tcsetattr(self.keyboard_fd,

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -34,7 +34,6 @@ from .accessories import (
 
 # TODO: Remove relative import once package names are normalized.
 from ..keyboard import BufferedKeyboard
-from ..terminal import HAS_TTY
 
 # 3rd-party
 import pytest
@@ -258,8 +257,7 @@ def test_kbhit_no_kb():
                                     term._keycodes,
                                     term.KEY_ESCAPE,
                                     term.keyboard_fd,
-                                    term._keyboard_decoder,
-                                    HAS_TTY)
+                                    term._keyboard_decoder)
         assert listener._char_is_ready(timeout=1.1) is False
         assert (math.floor(time.time() - stime) == 1.0)
     child()

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -31,8 +31,10 @@ from .accessories import (
     echo_off,
     xterms,
 )
-from ..keyboard import BufferedKeyboard  # TODO: Remove relative import once package names are normalized.
-from ..terminal import HAS_TTY, NoKeyboard
+
+# TODO: Remove relative import once package names are normalized.
+from ..keyboard import BufferedKeyboard
+from ..terminal import HAS_TTY
 
 # 3rd-party
 import pytest
@@ -223,6 +225,7 @@ def test_key_mode_no_kb():
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO())
+        from blessed.terminal import NoKeyboard
         with pytest.raises(NoKeyboard):
             with term.key_mode():
                 pass
@@ -250,7 +253,7 @@ def test_kbhit_no_kb():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
         assert term.keyboard_fd is None
-        
+
         listener = BufferedKeyboard(term._keymap,
                                     term._keycodes,
                                     term.KEY_ESCAPE,


### PR DESCRIPTION
- fix example bin programs
- first pass at fixing README.rst, needs work, its a mouthful.
- remove has_tty from class ``Key``, as NoKeyboard exception is always raised
- remove unused import in terminal.py, use full keyword arguments to ``Key`` class initializer
- fix identity issue of NoKeyboard exception after fork.