### PR TITLE
(3) blessed integration: Should check equality, not identity for str, int

### DIFF
--- a/blessings/tests/accessories.py
+++ b/blessings/tests/accessories.py
@@ -63,7 +63,7 @@ class as_subprocess(object):
 
     def __call__(self, *args, **kwargs):
         pid, master_fd = pty.fork()
-        if pid is self._CHILD_PID:
+        if pid == self._CHILD_PID:
             # child process executes function, raises exception
             # if failed, causing a non-zero exit code, using the
             # protected _exit() function of ``os``; to prevent the

--- a/blessings/tests/test_core.py
+++ b/blessings/tests/test_core.py
@@ -324,7 +324,7 @@ def test_IOUnsupportedOperation():
         assert term.stream == mock_stream
         assert term.does_styling is False
         assert term.is_a_tty is False
-        assert term.number_of_colors is 0
+        assert term.number_of_colors == 0
 
     child()
 

--- a/blessings/tests/test_core.py
+++ b/blessings/tests/test_core.py
@@ -235,7 +235,7 @@ def test_setupterm_invalid_has_no_styling():
 
         term = TestTerminal(kind='unknown', force_styling=True)
         assert term.kind is None
-        assert term.does_styling is False
+        assert not term.does_styling
         assert term.number_of_colors == 0
         warnings.resetwarnings()
 
@@ -322,8 +322,8 @@ def test_IOUnsupportedOperation():
 
         term = TestTerminal(stream=mock_stream)
         assert term.stream == mock_stream
-        assert term.does_styling is False
-        assert term.is_a_tty is False
+        assert not term.does_styling
+        assert not term.is_a_tty
         assert term.number_of_colors == 0
 
     child()
@@ -440,7 +440,7 @@ def test_win32_missing_tty_modules(monkeypatch):
             warnings.filterwarnings("ignore", category=UserWarning)
             import blessings.terminal
             imp.reload(blessings.terminal)
-            assert blessings.terminal.HAS_TTY is False
+            assert not blessings.terminal.HAS_TTY
             term = blessings.terminal.Terminal('ansi')
             assert term.height == 24
             assert term.width == 80

--- a/blessings/tests/test_keyboard.py
+++ b/blessings/tests/test_keyboard.py
@@ -43,7 +43,7 @@ if sys.version_info[0] == 3:
 def test_char_is_ready_interrupted():
     "_char_is_ready() should not be interrupted with a signal handler."
     pid, master_fd = pty.fork()
-    if pid is 0:
+    if pid == 0:
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -86,7 +86,7 @@ def test_char_is_ready_interrupted():
 def test_char_is_ready_interrupted_nonetype():
     "_char_is_ready() should also allow interruption with timeout of None."
     pid, master_fd = pty.fork()
-    if pid is 0:
+    if pid == 0:
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -130,7 +130,7 @@ def test_char_is_ready_interrupted_nonetype():
 def test_char_is_ready_interrupted_interruptable():
     "_char_is_ready() may be interrupted when interruptable=False."
     pid, master_fd = pty.fork()
-    if pid is 0:
+    if pid == 0:
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -175,7 +175,7 @@ def test_char_is_ready_interrupted_nonetype_interruptable():
     """_char_is_ready() may be interrupted when interruptable=False with
     timeout None."""
     pid, master_fd = pty.fork()
-    if pid is 0:
+    if pid == 0:
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -324,7 +324,7 @@ def test_keystroke_1s_keystroke_input_noinput_nokb():
 def test_keystroke_0s_keystroke_input_with_input():
     "0-second keystroke with input; Keypress should be immediately returned."
     pid, master_fd = pty.fork()
-    if pid is 0:
+    if pid == 0:
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -357,7 +357,7 @@ def test_keystroke_0s_keystroke_input_with_input():
 def test_keystroke_keystroke_input_with_input_slowly():
     "0-second keystroke with input; Keypress should be immediately returned."
     pid, master_fd = pty.fork()
-    if pid is 0:
+    if pid == 0:
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -400,7 +400,7 @@ def test_keystroke_0s_keystroke_input_multibyte_utf8():
     "0-second keystroke with multibyte utf-8 input; should decode immediately."
     # utf-8 bytes represent "latin capital letter upsilon".
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -434,7 +434,7 @@ def test_keystroke_0s_keystroke_input_multibyte_utf8():
 def test_keystroke_0s_raw_input_ctrl_c():
     "0-second keystroke with raw allows receiving ^C."
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -467,7 +467,7 @@ def test_keystroke_0s_raw_input_ctrl_c():
 def test_keystroke_0s_keystroke_input_sequence():
     "0-second keystroke with multibyte sequence; should decode immediately."
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -497,7 +497,7 @@ def test_keystroke_0s_keystroke_input_sequence():
 def test_keystroke_1s_keystroke_input_with_input():
     "1-second keystroke w/multibyte sequence; should return after ~1 second."
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -529,7 +529,7 @@ def test_keystroke_1s_keystroke_input_with_input():
 def test_esc_delay_keystroke_input_035():
     "esc_delay will cause a single ESC (\\x1b) to delay for 0.35."
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -564,7 +564,7 @@ def test_esc_delay_keystroke_input_035():
 def test_esc_delay_keystroke_input_135():
     "esc_delay=1.35 will cause a single ESC (\\x1b) to delay for 1.35."
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -599,7 +599,7 @@ def test_esc_delay_keystroke_input_135():
 def test_esc_delay_keystroke_input_timout_0():
     """esc_delay still in effect with timeout of 0 ("nonblocking")."""
     pid, master_fd = pty.fork()
-    if pid is 0:  # child
+    if pid == 0:  # child
         try:
             cov = __import__('cov_core_init').init()
         except ImportError:
@@ -649,9 +649,9 @@ def test_a_keystroke():
     "Test keyboard.Keystroke constructor with set arguments."
     from blessings.keyboard import Keystroke
     ks = Keystroke(ucs=u'x', code=1, name=u'the X')
-    assert ks._name is u'the X'
+    assert ks._name == u'the X'
     assert ks.name == ks._name
-    assert ks._code is 1
+    assert ks._code == 1
     assert ks.code == ks._code
     assert u'xx' == u'x' + ks
     assert ks.is_sequence is True
@@ -788,7 +788,7 @@ def test_resolve_sequence():
     ks = resolve_sequence(u'', mapper, codes)
     assert ks == u''
     assert ks.name is None
-    assert ks.code is None
+    assert ks.code == None
     assert ks.is_sequence is False
     assert repr(ks) in ("u''",  # py26, 27
                         "''",)  # py33
@@ -803,28 +803,28 @@ def test_resolve_sequence():
     ks = resolve_sequence(u'SEQ1', mapper, codes)
     assert ks == u'SEQ1'
     assert ks.name == u'KEY_SEQ1'
-    assert ks.code is 1
+    assert ks.code == 1
     assert ks.is_sequence is True
     assert repr(ks) in (u"KEY_SEQ1", "KEY_SEQ1")
 
     ks = resolve_sequence(u'LONGSEQ_longer', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
-    assert ks.code is 4
+    assert ks.code == 4
     assert ks.is_sequence is True
     assert repr(ks) in (u"KEY_LONGSEQ", "KEY_LONGSEQ")
 
     ks = resolve_sequence(u'LONGSEQ', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
-    assert ks.code is 4
+    assert ks.code == 4
     assert ks.is_sequence is True
     assert repr(ks) in (u"KEY_LONGSEQ", "KEY_LONGSEQ")
 
     ks = resolve_sequence(u'Lxxxxx', mapper, codes)
     assert ks == u'L'
     assert ks.name == u'KEY_L'
-    assert ks.code is 6
+    assert ks.code == 6
     assert ks.is_sequence is True
     assert repr(ks) in (u"KEY_L", "KEY_L")
 

--- a/blessings/tests/test_keyboard.py
+++ b/blessings/tests/test_keyboard.py
@@ -64,7 +64,7 @@ def test_char_is_ready_interrupted():
         with term.keystroke_input(raw=True):
             assert term.keystroke(timeout=1.05) == u''
         os.write(sys.__stdout__.fileno(), b'complete')
-        assert got_sigwinch is True
+        assert got_sigwinch
         if cov is not None:
             cov.stop()
             cov.save()
@@ -107,7 +107,7 @@ def test_char_is_ready_interrupted_nonetype():
         with term.keystroke_input(raw=True):
             term.keystroke(timeout=1)
         os.write(sys.__stdout__.fileno(), b'complete')
-        assert got_sigwinch is True
+        assert got_sigwinch
         if cov is not None:
             cov.stop()
             cov.save()
@@ -151,7 +151,7 @@ def test_char_is_ready_interrupted_interruptable():
         with term.keystroke_input(raw=True):
             term.keystroke(timeout=1.05, interruptable=False)
         os.write(sys.__stdout__.fileno(), b'complete')
-        assert got_sigwinch is True
+        assert got_sigwinch
         if cov is not None:
             cov.stop()
             cov.save()
@@ -196,7 +196,7 @@ def test_char_is_ready_interrupted_nonetype_interruptable():
         with term.keystroke_input(raw=True):
             term.keystroke(timeout=None, interruptable=False)
         os.write(sys.__stdout__.fileno(), b'complete')
-        assert got_sigwinch is True
+        assert got_sigwinch
         if cov is not None:
             cov.stop()
             cov.save()
@@ -264,8 +264,8 @@ def test_char_is_ready_no_kb():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
         assert term.keyboard_fd is None
-        assert term._char_is_ready(timeout=1.1) is False
-        assert (math.floor(time.time() - stime) == 1.0)
+        assert not term._char_is_ready(timeout=1.1)
+        assert math.floor(time.time() - stime) == 1.0
     child()
 
 
@@ -640,7 +640,7 @@ def test_keystroke_default_args():
     assert ks._code is None
     assert ks.code == ks._code
     assert u'x' == u'x' + ks
-    assert ks.is_sequence is False
+    assert not ks.is_sequence
     assert repr(ks) in ("u''",  # py26, 27
                         "''",)  # py33
 
@@ -654,7 +654,7 @@ def test_a_keystroke():
     assert ks._code == 1
     assert ks.code == ks._code
     assert u'xx' == u'x' + ks
-    assert ks.is_sequence is True
+    assert ks.is_sequence
     assert repr(ks) == "the X"
 
 
@@ -789,7 +789,7 @@ def test_resolve_sequence():
     assert ks == u''
     assert ks.name is None
     assert ks.code == None
-    assert ks.is_sequence is False
+    assert not ks.is_sequence
     assert repr(ks) in ("u''",  # py26, 27
                         "''",)  # py33
 
@@ -797,35 +797,35 @@ def test_resolve_sequence():
     assert ks == u'n'
     assert ks.name is None
     assert ks.code is None
-    assert ks.is_sequence is False
+    assert not ks.is_sequence
     assert repr(ks) in (u"u'n'", "'n'",)
 
     ks = resolve_sequence(u'SEQ1', mapper, codes)
     assert ks == u'SEQ1'
     assert ks.name == u'KEY_SEQ1'
     assert ks.code == 1
-    assert ks.is_sequence is True
+    assert ks.is_sequence
     assert repr(ks) in (u"KEY_SEQ1", "KEY_SEQ1")
 
     ks = resolve_sequence(u'LONGSEQ_longer', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
     assert ks.code == 4
-    assert ks.is_sequence is True
+    assert ks.is_sequence
     assert repr(ks) in (u"KEY_LONGSEQ", "KEY_LONGSEQ")
 
     ks = resolve_sequence(u'LONGSEQ', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
     assert ks.code == 4
-    assert ks.is_sequence is True
+    assert ks.is_sequence
     assert repr(ks) in (u"KEY_LONGSEQ", "KEY_LONGSEQ")
 
     ks = resolve_sequence(u'Lxxxxx', mapper, codes)
     assert ks == u'L'
     assert ks.name == u'KEY_L'
     assert ks.code == 6
-    assert ks.is_sequence is True
+    assert ks.is_sequence
     assert repr(ks) in (u"KEY_L", "KEY_L")
 
 


### PR DESCRIPTION
closes issue #81. Used shell expression::

    find * -type f -name '*.py' | xargs egrep '^[^#].* is ' | less

then ``/``searched for phrase ``is``

Please note that the TeamCity builds fail until acceptance of PR #91.