### PR TITLE
(3) blessed integration: __all__ as list

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -13,4 +13,4 @@ if ('3', '0', '0') <= _platform.python_version_tuple() < ('3', '2', '2+'):
 
 from .terminal import Terminal
 
-__all__ = ('Terminal',)
+__all__ = ['Terminal',]

--- a/blessings/_binterms.py
+++ b/blessings/_binterms.py
@@ -869,4 +869,4 @@ zen50
 ztx
 """.split()
 
-__all__ = ('binary_terminals',)
+__all__ = ['binary_terminals',]

--- a/blessings/keyboard.py
+++ b/blessings/keyboard.py
@@ -3,7 +3,7 @@
 __author__ = 'Jeff Quast <contact@jeffquast.com>'
 __license__ = 'MIT'
 
-__all__ = ('Keystroke', 'get_keyboard_codes', 'get_keyboard_sequences',)
+__all__ = ['Keystroke', 'get_keyboard_codes', 'get_keyboard_sequences',]
 
 import curses.has_key
 import collections

--- a/blessings/sequences.py
+++ b/blessings/sequences.py
@@ -4,7 +4,7 @@
 __author__ = 'Jeff Quast <contact@jeffquast.com>'
 __license__ = 'MIT'
 
-__all__ = ('init_sequence_patterns', 'Sequence', 'SequenceTextWrapper',)
+__all__ = ['init_sequence_patterns', 'Sequence', 'SequenceTextWrapper',]
 
 # built-ins
 import functools

--- a/blessings/tests/test_core.py
+++ b/blessings/tests/test_core.py
@@ -30,7 +30,7 @@ import pytest
 def test_export_only_Terminal():
     "Ensure only Terminal instance is exported for import * statements."
     import blessings
-    assert blessings.__all__ == ('Terminal',)
+    assert blessings.__all__ == ['Terminal',]
 
 
 def test_null_location(all_terms):


### PR DESCRIPTION
``__all__`` was formerly a tuple to remove the warning from pep257 tool, https://github.com/GreenSteam/pep257/issues/62

Closes issue #83

Please note that the TeamCity builds fail until acceptance of PR #91.