### PR TITLE
(3) use 'six' for py2/3 compatibility of string types

### DIFF
--- a/blessings/formatters.py
+++ b/blessings/formatters.py
@@ -1,6 +1,10 @@
 "This sub-module provides formatting functions."
+# standard imports
 import curses
 import sys
+
+# 3rd-party
+import six
 
 _derivatives = ('on', 'bright', 'on_bright',)
 
@@ -16,14 +20,8 @@ COLORS = set(['_'.join((derivitive, color))
 #: All valid compoundable names.
 COMPOUNDABLES = (COLORS | _compoundables)
 
-if sys.version_info[0] == 3:
-    text_type = str
-    basestring = str
-else:
-    text_type = unicode  # noqa
 
-
-class ParameterizingString(text_type):
+class ParameterizingString(six.text_type):
     """A Unicode string which can be called as a parameterizing termcap.
 
     For example::
@@ -42,7 +40,7 @@ class ParameterizingString(text_type):
         :arg name: name of this terminal capability.
         """
         assert len(args) and len(args) < 4, args
-        new = text_type.__new__(cls, args[0])
+        new = six.text_type.__new__(cls, args[0])
         new._normal = len(args) > 1 and args[1] or u''
         new._name = len(args) > 2 and args[2] or u'<not specified>'
         return new
@@ -63,7 +61,7 @@ class ParameterizingString(text_type):
         except TypeError as err:
             # If the first non-int (i.e. incorrect) arg was a string, suggest
             # something intelligent:
-            if len(args) and isinstance(args[0], basestring):
+            if len(args) and isinstance(args[0], six.string_types):
                 raise TypeError(
                     "A native or nonexistent capability template, %r received"
                     " invalid argument %r: %s. You probably misspelled a"
@@ -76,12 +74,12 @@ class ParameterizingString(text_type):
             # ignore 'tparm() returned NULL', you won't get any styling,
             # even if does_styling is True. This happens on win32 platforms
             # with http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses installed
-            if "tparm() returned NULL" not in text_type(err):
+            if "tparm() returned NULL" not in six.text_type(err):
                 raise
             return NullCallableString()
 
 
-class ParameterizingProxyString(text_type):
+class ParameterizingProxyString(six.text_type):
     """A Unicode string which can be called to proxy missing termcap entries.
 
     For example::
@@ -109,7 +107,7 @@ class ParameterizingProxyString(text_type):
         assert len(args) and len(args) < 4, args
         assert type(args[0]) is tuple, args[0]
         assert callable(args[0][1]), args[0][1]
-        new = text_type.__new__(cls, args[0][0])
+        new = six.text_type.__new__(cls, args[0][0])
         new._fmt_args = args[0][1]
         new._normal = len(args) > 1 and args[1] or u''
         new._name = len(args) > 2 and args[2] or u'<not specified>'
@@ -161,7 +159,7 @@ def get_proxy_string(term, attr):
     }.get(term_kind, {}).get(attr, None)
 
 
-class FormattingString(text_type):
+class FormattingString(six.text_type):
     """A Unicode string which can be called using ``text``,
     returning a new string, ``attr`` + ``text`` + ``normal``::
 
@@ -176,7 +174,7 @@ class FormattingString(text_type):
         :arg normal: terminating sequence for this attribute.
         """
         assert 1 <= len(args) <= 2, args
-        new = text_type.__new__(cls, args[0])
+        new = six.text_type.__new__(cls, args[0])
         new._normal = len(args) > 1 and args[1] or u''
         return new
 
@@ -191,12 +189,12 @@ class FormattingString(text_type):
         return text
 
 
-class NullCallableString(text_type):
+class NullCallableString(six.text_type):
     """A dummy callable Unicode to stand in for ``FormattingString`` and
     ``ParameterizingString`` for terminals that cannot perform styling.
     """
     def __new__(cls):
-        new = text_type.__new__(cls, u'')
+        new = six.text_type.__new__(cls, u'')
         return new
 
     def __call__(self, *args):

--- a/blessings/keyboard.py
+++ b/blessings/keyboard.py
@@ -5,10 +5,13 @@ __license__ = 'MIT'
 
 __all__ = ('Keystroke', 'get_keyboard_codes', 'get_keyboard_sequences',)
 
+# standard imports
 import curses.has_key
 import collections
 import curses
-import sys
+
+# 3rd-party
+import six
 
 if hasattr(collections, 'OrderedDict'):
     OrderedDict = collections.OrderedDict
@@ -52,14 +55,8 @@ for key in ('TAB', 'KP_MULTIPLY', 'KP_ADD', 'KP_SEPARATOR', 'KP_SUBTRACT',
     _lastval += 1
     setattr(curses, 'KEY_{0}'.format(key), _lastval)
 
-if sys.version_info[0] == 3:
-    text_type = str
-    unichr = chr
-else:
-    text_type = unicode  # noqa
 
-
-class Keystroke(text_type):
+class Keystroke(six.text_type):
     """A unicode-derived class for describing keyboard input returned by
     the ``inkey()`` method of ``Terminal``, which may, at times, be a
     multibyte sequence, providing properties ``is_sequence`` as ``True``
@@ -68,7 +65,7 @@ class Keystroke(text_type):
     such as ``KEY_LEFT``.
     """
     def __new__(cls, ucs='', code=None, name=None):
-        new = text_type.__new__(cls, ucs)
+        new = six.text_type.__new__(cls, ucs)
         new._name = name
         new._code = code
         return new
@@ -79,8 +76,8 @@ class Keystroke(text_type):
         return self._code is not None
 
     def __repr__(self):
-        return self._name is None and text_type.__repr__(self) or self._name
-    __repr__.__doc__ = text_type.__doc__
+        return self._name is None and six.text_type.__repr__(self) or self._name
+    __repr__.__doc__ = six.text_type.__doc__
 
     @property
     def name(self):
@@ -208,12 +205,12 @@ and numeric 0.
 DEFAULT_SEQUENCE_MIXIN = (
     # these common control characters (and 127, ctrl+'?') mapped to
     # an application key definition.
-    (unichr(10), curses.KEY_ENTER),
-    (unichr(13), curses.KEY_ENTER),
-    (unichr(8), curses.KEY_BACKSPACE),
-    (unichr(9), curses.KEY_TAB),
-    (unichr(27), curses.KEY_EXIT),
-    (unichr(127), curses.KEY_DC),
+    (six.unichr(10), curses.KEY_ENTER),
+    (six.unichr(13), curses.KEY_ENTER),
+    (six.unichr(8), curses.KEY_BACKSPACE),
+    (six.unichr(9), curses.KEY_TAB),
+    (six.unichr(27), curses.KEY_EXIT),
+    (six.unichr(127), curses.KEY_DC),
 
     (u"\x1b[A", curses.KEY_UP),
     (u"\x1b[B", curses.KEY_DOWN),

--- a/blessings/sequences.py
+++ b/blessings/sequences.py
@@ -11,23 +11,18 @@ import functools
 import textwrap
 import warnings
 import math
-import sys
 import re
 
 # local
 from ._binterms import binary_terminals as _BINTERM_UNSUPPORTED
 
 # 3rd-party
-import wcwidth  # https://github.com/jquast/wcwidth
+import wcwidth
+import six
 
 _BINTERM_UNSUPPORTED_MSG = (
     u"Terminal kind {0!r} contains binary-packed capabilities, blessings "
     u"is likely to fail to measure the length of its sequences.")
-
-if sys.version_info[0] == 3:
-    text_type = str
-else:
-    text_type = unicode  # noqa
 
 
 def _merge_sequences(inp):
@@ -424,7 +419,7 @@ class SequenceTextWrapper(textwrap.TextWrapper):
 SequenceTextWrapper.__doc__ = textwrap.TextWrapper.__doc__
 
 
-class Sequence(text_type):
+class Sequence(six.text_type):
     """
     This unicode-derived class understands the effect of escape sequences
     of printable length, allowing a properly implemented .rjust(), .ljust(),
@@ -437,7 +432,7 @@ class Sequence(text_type):
         :arg sequence_text: A string containing sequences.
         :arg term: Terminal instance this string was created with.
         """
-        new = text_type.__new__(cls, sequence_text)
+        new = six.text_type.__new__(cls, sequence_text)
         new._term = term
         return new
 
@@ -576,7 +571,7 @@ class Sequence(text_type):
         """
         outp = u''
         nxt = 0
-        for idx in range(0, text_type.__len__(self)):
+        for idx in range(0, six.text_type.__len__(self)):
             width = horizontal_distance(self[idx:], self._term)
             if width != 0:
                 nxt = idx + measure_length(self[idx:], self._term)

--- a/blessings/terminal.py
+++ b/blessings/terminal.py
@@ -1,5 +1,5 @@
 "This primary module provides the Terminal class."
-# standard modules
+# standard imports
 import collections
 import contextlib
 import functools

--- a/blessings/tests/accessories.py
+++ b/blessings/tests/accessories.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Accessories for automated py.test runner."""
-# std
+# standard imports
 from __future__ import with_statement
 import contextlib
 import subprocess
 import functools
 import traceback
 import termios
-import random
 import codecs
 import curses
 import sys
@@ -17,13 +16,10 @@ import os
 # local
 from blessings import Terminal
 
-# 3rd
+# 3rd-party
 import pytest
+import six
 
-if sys.version_info[0] == 3:
-    text_type = str
-else:
-    text_type = unicode  # noqa
 
 TestTerminal = functools.partial(Terminal, kind='xterm-256color')
 SEND_SEMAPHORE = SEMAPHORE = b'SEMAPHORE\n'
@@ -97,7 +93,7 @@ class as_subprocess(object):
                     cov.save()
                 os._exit(0)
 
-        exc_output = text_type()
+        exc_output = six.text_type()
         decoder = codecs.getincrementaldecoder(self.encoding)()
         while True:
             try:
@@ -138,7 +134,7 @@ def read_until_semaphore(fd, semaphore=RECV_SEMAPHORE,
     # process will read xyz\\r\\n -- this is how pseudo terminals
     # behave; a virtual terminal requires both carriage return and
     # line feed, it is only for convenience that \\n does both.
-    outp = text_type()
+    outp = six.text_type()
     decoder = codecs.getincrementaldecoder(encoding)()
     semaphore = semaphore.decode('ascii')
     while not outp.startswith(semaphore):
@@ -158,7 +154,7 @@ def read_until_semaphore(fd, semaphore=RECV_SEMAPHORE,
 def read_until_eof(fd, encoding='utf8'):
     """Read file descriptor ``fd`` until EOF. Return decoded string."""
     decoder = codecs.getincrementaldecoder(encoding)()
-    outp = text_type()
+    outp = six.text_type()
     while True:
         try:
             _exc = os.read(fd, 100)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ class SetupTest(setuptools.command.test.test):
 def main():
     extra = {
         'install_requires': [
-            'wcwidth>=0.1.0',
+            'wcwidth>=0.1.4',
+            'six>=1.9.0',
         ]
     }
     if sys.version_info < (2, 7,):


### PR DESCRIPTION
An unused import and some commenting of import groups slipped in.

Closes issue #80.