### PR TITLE
(1) leave pep8 and flake8 up to prospector, not pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = static_analysis,
+envlist = sa,
           py26,
           py27,
           py33,
@@ -11,24 +11,22 @@ skip_missing_interpreters = true
 [testenv]
 whitelist_externals = /bin/bash /bin/mv
 setenv = PYTHONIOENCODING=UTF8
-deps = pytest-flakes
-       pytest-xdist
-       pytest-pep8
+deps = pytest-xdist
        pytest-cov
        pytest
        mock
 commands = {envbindir}/py.test \
-               --strict --pep8 --flakes \
-               --junit-xml=results.{envname}.xml --verbose \
+               --strict --junit-xml=results.{envname}.xml \
+               --verbose --verbose \
                --cov blessings blessings/tests --cov-report=term-missing \
                {posargs}
            /bin/mv {toxinidir}/.coverage {toxinidir}/.coverage.{envname}
 
-[testenv:static_analysis]
+[testenv:sa]
+# static analysis
 deps = prospector[with_everything]
-commands = prospector \
+commands = -prospector \
                --die-on-tool-error \
-               --test-warnings \
                --doc-warnings \
                {toxinidir}
 


### PR DESCRIPTION
We disable the ``--pep8`` and ``--flakes`` arguments for py.test, leaving static analysis up to 'prospector', with the intent to disable the "ignore exit code" currently used (which is indicated by prefixing the 'prospector' command with a hyphen).

Please note that the TeamCity builds fail until acceptance of PR #91.

**NOTE**: this branch to be merged into PR #89, PR #88, PR #87, PR #86, PR #90 so that their passing tests may be assured.