### PR TITLE
(2) blessed integration: freebsd support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = blessed
+source = blessings
 
 [report]
-omit = blessed/tests/*
+omit = blessings/tests/*

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -6,7 +6,7 @@ ignore:
   - ^docs/
   # ignore tests and bin/ for the moment, their quality does not so much matter.
   - ^bin/
-  - ^blessed/tests/
+  - ^blessings/tests/
 
 test-warnings: true
 

--- a/blessings/_binterms.py
+++ b/blessings/_binterms.py
@@ -707,7 +707,6 @@ tvi950-rv
 tvi950-rv-2p
 tvi950-rv-4p
 tvipt
-unknown
 vanilla
 vc303
 vc404

--- a/blessings/tests/test_sequences.py
+++ b/blessings/tests/test_sequences.py
@@ -192,8 +192,8 @@ def test_horizontal_location(all_terms):
         assert (t.stream.getvalue() == expected_output), (
             repr(t.stream.getvalue()), repr(expected_output))
 
-    # skip 'screen', hpa is proxied (see later tests)
-    if all_terms != 'screen':
+    # skip 'screen', 'ansi': hpa is proxied (see later tests)
+    if all_terms not in ('screen', 'ansi'):
         child(all_terms)
 
 
@@ -211,7 +211,7 @@ def test_vertical_location(all_terms):
         assert (t.stream.getvalue() == expected_output)
 
     # skip 'screen', vpa is proxied (see later tests)
-    if all_terms != 'screen':
+    if all_terms not in ('screen', 'ansi'):
         child(all_terms)
 
 

--- a/tools/display-sighandlers.py
+++ b/tools/display-sighandlers.py
@@ -12,7 +12,11 @@ for name, value in [(signal_name, getattr(signal, signal_name))
                     for signal_name in dir(signal)
                     if signal_name.startswith('SIG')
                     and not signal_name.startswith('SIG_')]:
-    handler = signal.getsignal(value)
+    try:
+        handler = signal.getsignal(value)
+    except ValueError:
+        # FreeBSD: signal number out of range
+        handler = 'out of range'
     description = {
         signal.SIG_IGN: "ignored(SIG_IGN)",
         signal.SIG_DFL: "default(SIG_DFL)"

--- a/tools/teamcity-runtests.sh
+++ b/tools/teamcity-runtests.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-#
-# This script assumes that the project 'ptyprocess' is
-# available in the parent of the project's folder.
 set -e
 set -o pipefail
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps = pytest-xdist
 commands = {envbindir}/py.test \
                --strict --junit-xml=results.{envname}.xml \
                --verbose --verbose \
-               --cov blessings blessings/tests --cov-report=term-missing \
+               --cov blessings --cov-report=term-missing \
                {posargs}
            /bin/mv {toxinidir}/.coverage {toxinidir}/.coverage.{envname}
 


### PR DESCRIPTION
**Ensures tests pass on FreeBSD**. Many other PR's appear failed because FreeBSD is included in the builds on TeamCity, which fails until this PR is accepted.

- fixes coverage reporting (blessed => blessings), and reports to coveralls.io and as a github status on pull requests: https://coveralls.io/r/erikrose/blessings
- do not test ``ansi`` hpa/vpa: On FreeBSD, ansi has no such capability.  This is the reason such "proxies" authored in the code exist, anyway. This is actually just an error that we didn't catch.
- workaround for freebsd, which actually **has** an ``unknown`` termcap entry, we were intending to use it explicitly as a "will not be found in termcap database" test.
- ``ansi`` on freebsd tests **0** for ``number_of_colors``, use ``cons25`` on such system.
- handle ValueError in signal.getsignal in the accessory script ``tools/display-signalhandlers.py``, we don't actually **need** this script, it is just chained as part of the build to help in debugging issues with any given build agent, and any given OS problem reports.

You may see build failures from "ci/teamcity", this is my build farm that contains OSX, Solaris, FreeBSD and Linux.  Currently, the Solaris agent does not have curses support, so it is not (yet) included.  For FreeBSD, however, all tests will fail without this merge.