### PR TITLE
Fix & check hyperlinks: this will FAIL the build!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 docs/_build
 htmlcov
 .coveralls.yml
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,8 @@ install:
 
 script:
   - if [[ "${TOXENV}" == "py27" ]]; then tox -e sa; fi
-  - if [[ "${TOXENV}" == "py27" ]]; then tox -e docs; fi
+  - if [[ "${TOXENV}" == "py34" ]]; then tox -e docs; fi
   - tox -e $TOXENV
-
-after_success:
-  - if [[ "${TOXENV}" == "py34" ]]; then for f in ._coverage*; do mv $f `echo $f | tr -d '_'`; done; coverage combine; coveralls; fi
 
 notifications:
   email:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,7 +266,7 @@ autodoc_member_order = 'bysource'
 
 # when linking to standard python library, use and prefer python 3
 # documentation.
-intersphinx_mapping = {'http://docs.python.org/3/': None}
+intersphinx_mapping = {'https://docs.python.org/3/': None}
 
 # Both the class’ and the __init__ method’s docstring are concatenated and
 # inserted.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,7 +3,7 @@ Examples
 
 A few programs are provided with blessings to help interactively
 test the various API features, but also serve as examples of using
-blessings to develop various kinds of applications.
+blessings to develop applications.
 
 These examples are not distributed with the package -- they are
 only available in the github repository.  You can retrieve them

--- a/docs/further.rst
+++ b/docs/further.rst
@@ -12,7 +12,7 @@ Here are some recommended readings to help you along:
   listed in the column **Cap-name**.
 
 - `termios(4)
-  <http://www.openbsd.org/cgi-bin/man.cgi?query=termios&apropos=0&sektion=4>`_
+  <http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man4/termios.4>`_
   of your preferred posix-like operating system.
 
 - `The TTY demystified

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -106,9 +106,9 @@ Version History
   * Make ``python setup.py test`` work without spurious errors on 2.6.
   * Work around a tox parsing bug in its config file.
   * Make context managers clean up after themselves even if there's an
-    exception (Vitja Makarov :ghissue:`29`).
+    exception (Vitja Makarov :ghpull:`29`).
   * Parameterizing a capability no longer crashes when there is no tty
-    (Vitja Makarov :ghissue:`31`)
+    (Vitja Makarov :ghpull:`31`)
 
 1.5
   * Add syntactic sugar and documentation for ``enter_fullscreen``
@@ -172,4 +172,4 @@ Version History
 
 .. _`jquast/blessed`: https://github.com/jquast/blessed
 .. _PDCurses: http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses
-.. _`nose-progressive`: http://pypi.python.org/pypi/nose-progressive/
+.. _`nose-progressive`: https://pypi.python.org/pypi/nose-progressive/

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,6 +1,6 @@
 .. image:: https://img.shields.io/travis/erikrose/blessings.svg
     :alt: Travis Continous Integration
-    :target: https://travis-ci.orgerikrose/blessings/
+    :target: https://travis-ci.org/erikrose/blessings/
 
 .. image:: https://img.shields.io/teamcity/http/teamcity-master.pexpect.org/s/Blessings_BuildHead.png
     :alt: TeamCity Build status
@@ -130,7 +130,7 @@ The same program with *Blessings* is simply::
 Further Documentation
 ---------------------
 
-More documentation can be found at http://blessings.readthedocs.org/
+More documentation can be found at http://blessings.readthedocs.org/en/latest/
 
 Bugs, Contributing, Support
 ---------------------------
@@ -153,8 +153,8 @@ Blessings is under the MIT License. See the LICENSE file.
 
 .. _`issue tracker`: https://github.com/erikrose/blessings/issues/
 .. _curses: https://docs.python.org/library/curses.html
-.. _tigetstr: http://www.openbsd.org/cgi-bin/man.cgi?query=tigetstr&sektion=3
-.. _tparm: http://www.openbsd.org/cgi-bin/man.cgi?query=tparm&sektion=3
+.. _tigetstr: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tigetstr.3
+.. _tparm: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tparm.3
 .. _ansi: https://github.com/tehmaze/ansi
 .. _colorama: https://pypi.python.org/pypi/colorama
 .. _PDCurses: http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -152,7 +152,7 @@ License
 Blessings is under the MIT License. See the LICENSE file.
 
 .. _`issue tracker`: https://github.com/erikrose/blessings/issues/
-.. _curses: https://docs.python.org/library/curses.html
+.. _curses: https://docs.python.org/3/library/curses.html
 .. _tigetstr: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tigetstr.3
 .. _tparm: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tparm.3
 .. _ansi: https://github.com/tehmaze/ansi

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -578,14 +578,8 @@ context manager is used with numlock on:
 * ``KEY_KP_0`` through ``KEY_KP_9``
 
 .. _couleur: https://pypi.python.org/pypi/couleur
-.. _wcwidth: https://pypi.python.org/pypi/wcwidth
-.. _`cbreak(3)`: http://www.openbsd.org/cgi-bin/man.cgi?query=cbreak&apropos=0&sektion=3
-.. _`raw(3)`: http://www.openbsd.org/cgi-bin/man.cgi?query=raw&apropos=0&sektion=3
-.. _`curs_getch(3)`: http://www.openbsd.org/cgi-bin/man.cgi?query=curs_getch&apropos=0&sektion=3
-.. _`termios(4)`: http://www.openbsd.org/cgi-bin/man.cgi?query=termios&apropos=0&sektion=4
-.. _`terminfo(5)`: http://invisible-island.net/ncurses/man/terminfo.5.html
-.. _tparm: http://www.openbsd.org/cgi-bin/man.cgi?query=tparm&sektion=3
+.. _`cbreak(3)`: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/cbreak.3
+.. _`raw(3)`: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/raw.3
+.. _`curs_getch(3)`: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/curs_getch.3
+.. _`terminfo(5)`: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man4/termios.3
 .. _SIGWINCH: https://en.wikipedia.org/wiki/SIGWINCH
-.. _`API Documentation`: http://blessed.rtfd.org
-.. _`PDCurses`: http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses
-.. _`ansi`: https://github.com/tehmaze/ansi

--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -106,7 +106,7 @@ def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """
     app = inliner.document.settings.env.app
     #app.info('user link %r' % text)
-    ref = 'https://www.github.com/' + text
+    ref = 'https://github.com/' + text
     node = nodes.reference(rawtext, text, refuri=ref, **options)
     return [node], []
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,15 +51,17 @@ commands = prospector \
 
 [testenv:docs]
 whitelist_externals=echo
-basepython=python
+basepython=python3.4
 deps=sphinx
      sphinx_rtd_theme
      sphinx-paramlinks
 
-commands = sphinx-build -v -W -b html -d {toxinidir}/docs/_build/doctrees \
+commands = sphinx-build -v -W -b html -blinkcheck \
+               -d {toxinidir}/docs/_build/doctrees \
                docs \
                {toxinidir}/docs/_build/html
-          echo "open {toxinidir}/docs/_build/html/index.html for review"
+           echo "open {toxinidir}/docs/_build/html/index.html for review"
+
 
 [pytest]
 # py.test fixtures conflict with pyflakes


### PR DESCRIPTION
Fix a number of hyperlinks, check them while build docs.

Because of many references to artifacts that are only available **after** pull request #104 is merged, the '-blinkcheck' option of the 'docs' target is failing for the following urls!

https://github.com/erikrose/blessings/blob/master/bin/editor.py - HTTP Error 404: Not Found
https://github.com/erikrose/blessings/blob/master/bin/progress_bar.py - HTTP Error 404: Not Found
https://github.com/erikrose/blessings/blob/master/bin/editor.py - HTTP Error 404: Not Found
https://github.com/erikrose/blessings/blob/master/bin/tprint.py - HTTP Error 404: Not Found
https://github.com/erikrose/blessings/blob/master/bin/on_resize.py - HTTP Error 404: Not Found
https://github.com/erikrose/blessings/blob/master/blessings/editor.py - HTTP Error 404: Not Found
http://blessings.readthedocs.org/en/latest/contributing.html - HTTP Error 404: OK

also gitignore .DS_Store