### PR TITLE
Polish style in setup.py.

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -8,8 +8,8 @@ ignore-patterns:
   # ignore these, their quality does not so much matter.
   - ^blessings/tests/
   - ^tools/
-  # not maintained
-  - ^fabfile.py
+  # EK doesn't want setup.py checked
+  - ^setup.py
 
 test-warnings: true
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python
-"""setuptools entry point for package management."""
 import subprocess
 import sys
-import os
+from os import getenv
+from os.path import dirname, join
 
 import setuptools
 import setuptools.command.develop
 import setuptools.command.test
 
-HERE = os.path.dirname(__file__)
-
 
 class SetupDevelop(setuptools.command.develop.develop):
-
     """Docstring is overwritten."""
 
     def run(self):
@@ -23,7 +20,7 @@ class SetupDevelop(setuptools.command.develop.develop):
         - Ensures tox, ipython, wheel is installed for convenience and testing.
         - Call super()'s run method.
         """
-        assert os.getenv('VIRTUAL_ENV'), 'You should be in a virtualenv'
+        assert getenv('VIRTUAL_ENV'), 'You should be in a virtualenv'
         subprocess.check_call(('pip', 'install', 'tox', 'ipython', 'wheel'))
 
         # Call super() (except develop is an old-style class, so we must call
@@ -34,7 +31,6 @@ SetupDevelop.__doc__ = setuptools.command.develop.develop.__doc__
 
 
 class SetupTest(setuptools.command.test.test):
-
     """Docstring is overwritten."""
 
     def run(self):
@@ -43,7 +39,7 @@ class SetupTest(setuptools.command.test.test):
 
 SetupTest.__doc__ = setuptools.command.test.test.__doc__
 
-EXTRA = {
+kwargs = {
     'install_requires': [
         'wcwidth>=0.1.4',
         'six>=1.9.0',
@@ -53,14 +49,15 @@ EXTRA = {
 if sys.version_info < (2, 7):
     # we make use of collections.ordereddict: for python 2.6 we require the
     # assistance of the 'orderddict' module which backports the same.
-    EXTRA['install_requires'].extend(['ordereddict>=1.1'])
+    kwargs['install_requires'].extend(['ordereddict>=1.1'])
 
 setuptools.setup(
     name='blessings',
     version='1.9.5',
     description=('A thin, practical wrapper around terminal coloring, '
                  'styling, positioning, and keyboard input.'),
-    long_description=open(os.path.join(HERE, 'docs/intro.rst')).read(),
+    long_description=open(join(dirname(__file__),
+                               'docs', 'intro.rst')).read(),
     author='Erik Rose, Jeff Quast',
     author_email='erikrose@grinchcentral.com',
     license='MIT',
@@ -93,5 +90,5 @@ setuptools.setup(
               'ansi', 'xterm'],
     cmdclass={'develop': SetupDevelop,
               'test': SetupTest},
-    **EXTRA
+    **kwargs
 )


### PR DESCRIPTION
* CAPITAL symbols should be reserved for constants.
* Import things more deeply to keep code itself shorter and more readable.
* There's no need to explain what a setup.py is.

(Opening this for Travis because I can't get the tests to pass locally.)