### PR TITLE
Return 0 from 'number_of_colors' when does_styling is False

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -337,6 +337,9 @@ class Terminal(object):
         # don't name it after the underlying capability, because we deviate
         # slightly from its behavior, and we might someday wish to give direct
         # access to it.
+        if not self._does_styling:
+            return 0
+
         colors = tigetnum('colors')  # Returns -1 if no color support, -2 if no
                                      # such cap.
         #  self.__dict__['colors'] = ret  # Cache it. It's not changing.


### PR DESCRIPTION
When `does_styling` is False, we never call `setupterm`. This means the call to `tigetnum` will raise. Instead, return 0 if `does_styling` is False.