### PR TITLE
Recognize correctly the negated form of the capabilities.

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -416,9 +416,11 @@ def derivative_colors(colors):
 COLORS = set(['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan',
               'white'])
 COLORS.update(derivative_colors(COLORS))
-COMPOUNDABLES = (COLORS |
-                 set(['bold', 'underline', 'reverse', 'blink', 'dim', 'italic',
-                      'shadow', 'standout', 'subscript', 'superscript']))
+SINGLES = set(['bold', 'reverse', 'blink', 'dim', 'flash'])
+DUALS = set([
+    'underline', 'italic', 'shadow', 'standout', 'subscript', 'superscript'
+])
+COMPOUNDABLES = (COLORS | SINGLES | DUALS | set(['no_' + c for c in DUALS]))
 
 
 class ParametrizingString(text_type):
@@ -543,11 +545,12 @@ def split_into_formatters(compound):
 
     >>> split_into_formatters('bold_underline_bright_blue_on_red')
     ['bold', 'underline', 'bright_blue', 'on_red']
-
+    >>> split_into_formatters('red_no_italic_shadow_on_bright_cyan')
+    ['red', 'no_italic', 'shadow', 'on_bright_cyan']
     """
     merged_segs = []
     # These occur only as prefixes, so they can always be merged:
-    mergeable_prefixes = ['on', 'bright', 'on_bright']
+    mergeable_prefixes = ['no', 'on', 'bright', 'on_bright']
     for s in compound.split('_'):
         if merged_segs and merged_segs[-1] in mergeable_prefixes:
             merged_segs[-1] += '_' + s

--- a/blessings/tests.py
+++ b/blessings/tests.py
@@ -210,6 +210,12 @@ def test_formatting_functions():
     eq_(t.on_bright_red_bold_bright_green_underline('meh'),
         t.on_bright_red + t.bold + t.bright_green + t.underline + u'meh' +
                           t.normal)
+    # Add also some negated vversions
+    eq_(t.bold_no_underline_green_on_red('boo'),
+        t.bold + t.no_underline + t.green + t.on_red + u'boo' + t.normal)
+    eq_(t.on_bright_red_no_italic_bright_green_underline('meh'),
+        t.on_bright_red + t.no_italic + t.bright_green + t.underline +
+        u'meh' + t.normal)
 
 
 def test_formatting_functions_without_tty():
@@ -221,6 +227,9 @@ def test_formatting_functions_without_tty():
     eq_(t.bold_green(u'boö'), u'boö')
     eq_(t.bold_underline_green_on_red('loo'), u'loo')
     eq_(t.on_bright_red_bold_bright_green_underline('meh'), u'meh')
+    # Add some negated expressions
+    eq_(t.bold_no_underline_green_on_red('loo'), u'loo')
+    eq_(t.on_bright_red_bold_bright_green_no_underline('meh'), u'meh')
 
 
 def test_nice_formatting_errors():


### PR DESCRIPTION
This patch introduces 2 main changes:
- COMPOUNDABLES includes the negated version of the 'underline',
  'italic'...  so now it includes also 'no_italic' and similar.
- split_into_formatters considers also the 'no' prefix.

With this changes expressions like:
t.red_no_underline
t.no_italic_bright_yellow

work as expected.

Fixes Issue #134