### PR TITLE
Include docs in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.rst
 include LICENSE
 include tox.ini
+graft docs
+graft blessings/tests


### PR DESCRIPTION
Hi,
PyPI tarballs don't contain docs, could you add them to future releases? We at Gentoo usually rely on those.