### PR TITLE
Fix error when TERM is unset or improperly set

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -94,8 +94,13 @@ class Terminal(object):
             # init sequences to the stream if it has a file descriptor, and
             # send them to stdout as a fallback, since they have to go
             # somewhere.
-            setupterm(kind or environ.get('TERM', 'unknown'),
-                      self._init_descriptor)
+            try:
+                setupterm(kind or environ.get('TERM', 'dumb'),
+                          self._init_descriptor)
+            except:
+                # There was an error setting up the terminal, either curses is
+                # not supported or TERM is incorrectly set. Fall back to dumb.
+                self._does_styling = False
 
         self.stream = stream
 

--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -97,7 +97,7 @@ class Terminal(object):
             try:
                 setupterm(kind or environ.get('TERM', 'dumb'),
                           self._init_descriptor)
-            except:
+            except curses.error:
                 # There was an error setting up the terminal, either curses is
                 # not supported or TERM is incorrectly set. Fall back to dumb.
                 self._does_styling = False


### PR DESCRIPTION
Closes #39. 

This is an alternative, simpler solution than merging the blessed-integration branch, because that seems stalled. 

If TERM is unset, we should default to a dumb term, as we cannot be sure colors are supported, which matches the behavior of less, for example.

If there is an error reading the TERM variable, we should fall back to not outputing any color, which mimics less again.

I tried to write some simple tests for this but the results seem to be cached, even across Terminal instances? Is this happening somehow, and is there a way to disable the cache?