### PR TITLE
Default to TERM=dumb even if $TERM is set but empty

### DIFF
--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -95,7 +95,7 @@ class Terminal(object):
             # send them to stdout as a fallback, since they have to go
             # somewhere.
             try:
-                setupterm(kind or environ.get('TERM', 'dumb'),
+                setupterm(kind or environ.get('TERM', 'dumb') or 'dumb',
                           self._init_descriptor)
             except curses.error:
                 # There was an error setting up the terminal, either curses is


### PR DESCRIPTION
We run into this because a Gentoo tinderbox system trying to build current Mozilla Firefox failed to do so because `TERM` wasn't set. Well, it was set but it was set to an empty value, e.g. `TERM=`.

This small addition to #137 will fix such scenarios as well.

In theory a user could still have set `TERM=" "` which will cause troubles. Not sure if you want to do something like
```Python
termEnv = environ.get('TERM', 'dumb')
if not termEnv.strip():
    termEnv = 'dumb'

setupterm(kind or termEnv,
```
to catch almost all scenarios...