### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ python:
   - 3.5
   - 3.6
   - pypy
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
   - pip install -q nose

--- a/blessings/__init__.py
+++ b/blessings/__init__.py
@@ -418,14 +418,14 @@ def derivative_colors(colors):
                [('on_bright_' + c) for c in colors])
 
 
-COLORS = set(['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan',
-              'white'])
+COLORS = {'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan',
+              'white'}
 COLORS.update(derivative_colors(COLORS))
-SINGLES = set(['bold', 'reverse', 'blink', 'dim', 'flash'])
-DUALS = set([
+SINGLES = {'bold', 'reverse', 'blink', 'dim', 'flash'}
+DUALS = {
     'underline', 'italic', 'shadow', 'standout', 'subscript', 'superscript'
-])
-COMPOUNDABLES = (COLORS | SINGLES | DUALS | set(['no_' + c for c in DUALS]))
+}
+COMPOUNDABLES = (COLORS | SINGLES | DUALS | {'no_' + c for c in DUALS})
 
 
 class ParametrizingString(text_type):

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,py}
+envlist = py{27,34,35,36,37,py}
 
 [testenv]
 commands = nosetests blessings


### PR DESCRIPTION
* Add support for Python 3.7, which needs Xenial and sudo on Travis CI (https://github.com/travis-ci/travis-ci/issues/9815).

* Upgraded Python syntax with [pyupgrade](https://github.com/asottile/pyupgrade).