### PR TITLE
Add support for Python 3.8 and 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
   - pypy
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  - pypy3
 
 install:
   - pip install -q nose

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,py}
+envlist = py{27,34,35,36,37,38,39,py}
 
 [testenv]
 commands = nosetests blessings


### PR DESCRIPTION
Could also consider dropping the EO versions at some point: 2.7, 3.4, 3.5.